### PR TITLE
Fix customizing project save

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3563,7 +3563,7 @@ function App() {
                   });
                   
                   setProjects(updatedProjects);
-                  updateProjects(updatedProjects);
+                  updateProjects(() => updatedProjects);
                   setShowCustomizeModal(false);
                   setCustomizingProject(null);
                 }}


### PR DESCRIPTION
## Summary
- fix project state updater when customizing project names

## Testing
- `npm run lint` *(fails: many unused var errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888d50e4780832cbc8e58a6aed5818a