### PR TITLE
Read Supabase config from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 ## 🚀 Como Hospedar (SUPER FÁCIL)
 
 ### 1. Configurar Supabase
-Antes de fazer o deploy, configure estas variáveis no Netlify:
+Antes de fazer o deploy, crie um arquivo `.env` (ou copie `.env.example`) e configure estas variáveis no Netlify:
 
 ```
 VITE_SUPABASE_URL=sua_url_aqui
 VITE_SUPABASE_ANON_KEY=sua_chave_aqui
 ```
+Essas variáveis são lidas diretamente em `src/App.jsx` via `import.meta.env`.
+Um modelo está disponível em `.env.example`.
 
 ### 2. Deploy no Netlify
 - Faça upload deste repositório no GitHub

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -492,8 +492,8 @@ function App() {
   }, [showDropdown]);
 
   // Configuração do Supabase
-  const SUPABASE_URL = 'https://ujpvyslrosmismgbcczl.supabase.co';
-  const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVqcHZ5c2xyb3NtaXNtZ2JjY3psIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA3NzU5MDgsImV4cCI6MjA2NjM1MTkwOH0.XkgwQ4VF7_7plt8-cw9VsatX4WwLolZEO6a6YtovUFs';
+  const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+  const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
   // Estados para arquivos
   const [files, setFiles] = useState([]);


### PR DESCRIPTION
## Summary
- use `import.meta.env` for Supabase URL and key
- document env vars used in `src/App.jsx`
- add `.env.example` template and mention it in the README

## Testing
- `npm run lint` *(fails: missing `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6888d7e62e58832caefce10efc221f9c