### PR TITLE
Fix board selector refresh after customization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3563,8 +3563,16 @@ function App() {
                     return project;
                   });
                   
-                  setProjects(updatedProjects);
                   updateProjects(() => updatedProjects);
+
+                  if (currentProject?.id === customizingProject.id) {
+                    setCurrentProject(customizingProject);
+                    setRefreshKey(prev => prev + 1);
+                  } else if (currentSubProject?.id === customizingProject.id) {
+                    setCurrentSubProject(customizingProject);
+                    setRefreshKey(prev => prev + 1);
+                  }
+
                   setShowCustomizeModal(false);
                   setCustomizingProject(null);
                 }}


### PR DESCRIPTION
## Summary
- update project customization save handler to update current project or subproject
- refresh app when saving customizations

## Testing
- `pnpm lint` *(fails: eslint not found earlier until install; fails with existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68894889e424832cb0ba9eb132fe44a7