### PR TITLE
Fix board name refresh after customization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3549,7 +3549,7 @@ function App() {
                     return project;
                   });
 
-                  setProjects(updatedProjects);
+                  updateProjects(() => updatedProjects);
 
                   if (currentSubProject?.id === customizingProject.id) {
                     setCurrentSubProject(customizingProject);
@@ -3563,7 +3563,7 @@ function App() {
                     }
                   }
 
-                  updateProjects(() => updatedProjects);
+                  setRefreshKey(prev => prev + 1);
                   setShowCustomizeModal(false);
                   setCustomizingProject(null);
                 }}


### PR DESCRIPTION
## Summary
- ensure saving customizations updates the project list with `updateProjects`
- refresh the relevant project and force rerender so board names update immediately

## Testing
- `pnpm lint` *(fails: 51 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68894bbb80e8832cb88b4ecce59d0008