### PR TITLE
Enable task navigation from My Tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1047,7 +1047,7 @@ function App() {
     // Encontrar o projeto
     const project = projects.find(p => p.id === task.projectId);
     if (!project) return;
-    
+
     // Se for um subprojeto, navegar para ele
     if (task.subProjectId) {
       const subProject = project.subProjects?.find(sp => sp.id === task.subProjectId);
@@ -1055,12 +1055,14 @@ function App() {
         setCurrentProject(project);
         setCurrentSubProject(subProject);
         setCurrentBoardType(task.boardType);
+        setCurrentView('subproject');
       }
     } else {
       // Se for projeto principal
       setCurrentProject(project);
       setCurrentSubProject(null);
       setCurrentBoardType(task.boardType);
+      setCurrentView('project');
     }
   };
 


### PR DESCRIPTION
## Summary
- clicking a task in **Minhas Tarefas** now switches to the related project or subproject view

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889701600a8832ca87c26a3f9fca3b2