### PR TITLE
refactor: centralize supabase config and modularize app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
 import './App.css'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useUsers } from './hooks/useUsers'
 import { useFiles } from './hooks/useFiles'
 import { useBoards } from './hooks/useBoards'
 import { useRealtimeProjects } from './hooks/useRealtimeProjects'
+import ProjectsView from './components/ProjectsView'
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config/supabase'
 
 export default function App() {
   const [projects, setProjects] = useState([])
@@ -25,12 +27,10 @@ export default function App() {
 
   async function loadUserProjects(userKey) {
     try {
-      const url = import.meta.env.VITE_SUPABASE_URL
-      const key = import.meta.env.VITE_SUPABASE_ANON_KEY
-      const response = await fetch(`${url}/rest/v1/brickflow_data`, {
+      const response = await fetch(`${SUPABASE_URL}/rest/v1/brickflow_data`, {
         headers: {
-          apikey: key,
-          Authorization: `Bearer ${key}`
+          apikey: SUPABASE_ANON_KEY,
+          Authorization: `Bearer ${SUPABASE_ANON_KEY}`
         }
       })
 
@@ -59,9 +59,26 @@ export default function App() {
     <div className="app">
       <h1>BrickFlow</h1>
       {isLoggedIn ? (
-        <div>Bem-vindo, {currentUser.displayName}</div>
+        currentView === 'home' ? (
+          <ProjectsView
+            projects={projects}
+            onSelect={(project) => {
+              setCurrentProject(project)
+              setCurrentView('project')
+            }}
+          />
+        ) : (
+          <div>
+            <h2>{currentProject?.name}</h2>
+            <button onClick={() => setCurrentView('home')}>Voltar</button>
+          </div>
+        )
       ) : (
-        <div>{showLoginModal && <button onClick={() => handleLogin('user','1234')}>Login</button>}</div>
+        <div>
+          {showLoginModal && (
+            <button onClick={() => handleLogin('user', '1234')}>Login</button>
+          )}
+        </div>
       )}
     </div>
   )

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react'
+import { describe, it, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+
+describe('App', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('renders without crashing', async () => {
+    const App = (await import('../App.jsx')).default
+    render(<App />)
+  })
+})

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,0 +1,8 @@
+export default function ProjectCard({ project, onSelect }) {
+  return (
+    <div className="project-card" onClick={() => onSelect(project)}>
+      <h3>{project.name}</h3>
+      {project.description && <p>{project.description}</p>}
+    </div>
+  )
+}

--- a/src/components/ProjectsView.jsx
+++ b/src/components/ProjectsView.jsx
@@ -1,0 +1,15 @@
+import ProjectCard from './ProjectCard'
+
+export default function ProjectsView({ projects, onSelect }) {
+  if (!projects || projects.length === 0) {
+    return <p>Nenhum projeto disponível.</p>
+  }
+
+  return (
+    <div className="projects-view">
+      {projects.map(project => (
+        <ProjectCard key={project.id} project={project} onSelect={onSelect} />
+      ))}
+    </div>
+  )
+}

--- a/src/config/__tests__/supabase.test.js
+++ b/src/config/__tests__/supabase.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('supabase config', () => {
+  it('throws when env variables are missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', '')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '')
+    await expect(import('../supabase.js')).rejects.toThrow(/VITE_SUPABASE_URL/)
+  })
+
+  it('exports variables when present', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
+    const config = await import('../supabase.js')
+    expect(config.SUPABASE_URL).toBe('https://example.supabase.co')
+    expect(config.SUPABASE_ANON_KEY).toBe('anon')
+  })
+})

--- a/src/config/supabase.js
+++ b/src/config/supabase.js
@@ -1,0 +1,15 @@
+const url = import.meta.env.VITE_SUPABASE_URL
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+if (!url) {
+  throw new Error('Environment variable VITE_SUPABASE_URL is required')
+}
+
+if (!anonKey) {
+  throw new Error('Environment variable VITE_SUPABASE_ANON_KEY is required')
+}
+
+export const SUPABASE_URL = url
+export const SUPABASE_ANON_KEY = anonKey
+
+export default { SUPABASE_URL, SUPABASE_ANON_KEY }

--- a/src/hooks/__tests__/useFiles.test.js
+++ b/src/hooks/__tests__/useFiles.test.js
@@ -1,13 +1,23 @@
 import { renderHook } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
-import { useFiles } from '../useFiles'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 function wrapper({ children }) {
   return children
 }
 
 describe('useFiles', () => {
-  it('should start with empty list', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('should start with empty list', async () => {
+    const { useFiles } = await import('../useFiles')
     const { result } = renderHook(() => useFiles(null, null, {}), { wrapper })
     expect(result.current.files).toEqual([])
   })

--- a/src/hooks/__tests__/useUsers.test.js
+++ b/src/hooks/__tests__/useUsers.test.js
@@ -1,13 +1,27 @@
 import { renderHook } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
-import { useUsers } from '../useUsers'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 function wrapper({ children }) {
   return children
 }
 
 describe('useUsers', () => {
-  it('should initialize without user', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('should initialize without user', async () => {
+    const { useUsers } = await import('../useUsers')
     const { result } = renderHook(() => useUsers(), { wrapper })
     expect(result.current.currentUser).toBeNull()
   })

--- a/src/hooks/useFiles.js
+++ b/src/hooks/useFiles.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { debugLog } from '../utils/debugLog'
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from '../config/supabase'
 
 export function useFiles(currentProject, currentSubProject, currentUser) {
   const [files, setFiles] = useState([])
@@ -7,16 +8,13 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
   const [previewFile, setPreviewFile] = useState(null)
   const [showPreviewModal, setShowPreviewModal] = useState(false)
 
-  const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
-  const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
-
   const saveFileToSupabase = async (fileData) => {
     try {
       await fetch(`${SUPABASE_URL}/rest/v1/brickflow_files`, {
         method: 'POST',
         headers: {
-          'apikey': SUPABASE_KEY,
-          'Authorization': `Bearer ${SUPABASE_KEY}`,
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(fileData)
@@ -30,8 +28,8 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
     try {
       const response = await fetch(`${SUPABASE_URL}/rest/v1/brickflow_files?order=created_at.desc`, {
         headers: {
-          'apikey': SUPABASE_KEY,
-          'Authorization': `Bearer ${SUPABASE_KEY}`
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
         }
       })
       if (response.ok) {
@@ -48,8 +46,8 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
       await fetch(`${SUPABASE_URL}/rest/v1/brickflow_files?id=eq.${fileId}`, {
         method: 'DELETE',
         headers: {
-          'apikey': SUPABASE_KEY,
-          'Authorization': `Bearer ${SUPABASE_KEY}`
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
         }
       })
     } catch (error) {

--- a/src/hooks/useUsers.js
+++ b/src/hooks/useUsers.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { debugLog } from '../utils/debugLog'
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from '../config/supabase'
 
 export function useUsers(loadUserProjects) {
   const [currentUser, setCurrentUser] = useState(null)
@@ -8,15 +9,12 @@ export function useUsers(loadUserProjects) {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [allUsers, setAllUsers] = useState([])
 
-  const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
-  const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
-
   const saveUserToSupabase = async (userData) => {
     try {
       const checkResponse = await fetch(`${SUPABASE_URL}/rest/v1/brickflow_users?username=eq.${userData.username}`, {
         headers: {
-          'apikey': SUPABASE_KEY,
-          'Authorization': `Bearer ${SUPABASE_KEY}`
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
         }
       })
 
@@ -26,8 +24,8 @@ export function useUsers(loadUserProjects) {
           await fetch(`${SUPABASE_URL}/rest/v1/brickflow_users?username=eq.${userData.username}`, {
             method: 'PATCH',
             headers: {
-              'apikey': SUPABASE_KEY,
-              'Authorization': `Bearer ${SUPABASE_KEY}`,
+              'apikey': SUPABASE_ANON_KEY,
+              'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
               'Content-Type': 'application/json'
             },
             body: JSON.stringify({
@@ -49,8 +47,8 @@ export function useUsers(loadUserProjects) {
           await fetch(`${SUPABASE_URL}/rest/v1/brickflow_users`, {
             method: 'POST',
             headers: {
-              'apikey': SUPABASE_KEY,
-              'Authorization': `Bearer ${SUPABASE_KEY}`,
+              'apikey': SUPABASE_ANON_KEY,
+              'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
               'Content-Type': 'application/json'
             },
             body: JSON.stringify(userDataForSupabase)
@@ -66,8 +64,8 @@ export function useUsers(loadUserProjects) {
     try {
       const response = await fetch(`${SUPABASE_URL}/rest/v1/brickflow_users`, {
         headers: {
-          'apikey': SUPABASE_KEY,
-          'Authorization': `Bearer ${SUPABASE_KEY}`
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
         }
       })
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import LegacyApp from './LegacyApp.jsx'
+import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <LegacyApp />
+    <App />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- centralize Supabase credentials in a dedicated config module
- introduce modular project view components and wire them into App
- cover config loading and App init with tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688e88a6b948832c9cb2989e84f91330