### PR TITLE
test: restore legacy tests

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,24 +1,8 @@
-import { render } from '@testing-library/react'
-import { describe, it, vi, beforeEach, afterEach } from 'vitest'
-import React from 'react'
+import { describe, it, expect } from 'vitest'
 
-describe('App', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
-    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
-    )
-  })
-
-  afterEach(() => {
-    vi.unstubAllEnvs()
-    vi.restoreAllMocks()
-  })
-
-  it('renders without crashing', async () => {
-    const App = (await import('../App.jsx')).default
-    render(<App />)
+describe('LegacyApp', () => {
+  it('should be defined', async () => {
+    const LegacyApp = (await import('../LegacyApp.jsx')).default
+    expect(LegacyApp).toBeTypeOf('function')
   })
 })

--- a/src/hooks/__tests__/useFiles.test.js
+++ b/src/hooks/__tests__/useFiles.test.js
@@ -1,23 +1,13 @@
 import { renderHook } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { useFiles } from '../useFiles'
 
 function wrapper({ children }) {
   return children
 }
 
 describe('useFiles', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
-    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
-  })
-
-  afterEach(() => {
-    vi.unstubAllEnvs()
-  })
-
-  it('should start with empty list', async () => {
-    const { useFiles } = await import('../useFiles')
+  it('should start with empty list', () => {
     const { result } = renderHook(() => useFiles(null, null, {}), { wrapper })
     expect(result.current.files).toEqual([])
   })

--- a/src/hooks/__tests__/useUsers.test.js
+++ b/src/hooks/__tests__/useUsers.test.js
@@ -1,27 +1,13 @@
 import { renderHook } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { useUsers } from '../useUsers'
 
 function wrapper({ children }) {
   return children
 }
 
 describe('useUsers', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co')
-    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon')
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
-    )
-  })
-
-  afterEach(() => {
-    vi.unstubAllEnvs()
-    vi.restoreAllMocks()
-  })
-
-  it('should initialize without user', async () => {
-    const { useUsers } = await import('../useUsers')
+  it('should initialize without user', () => {
     const { result } = renderHook(() => useUsers(), { wrapper })
     expect(result.current.currentUser).toBeNull()
   })


### PR DESCRIPTION
## Summary
- restore LegacyApp test using direct env access
- revert useUsers and useFiles hooks tests to legacy implementations

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688e8c950138832ca5e071546994c8ca