### PR TITLE
refactor: remove checkbox checkmarks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -598,7 +598,7 @@ body {
   margin-bottom: 0.5rem;
 }
 
-.task-header input[type="checkbox"] {
+.task-header [data-slot="checkbox"] {
   margin-top: 0.25rem;
   cursor: pointer;
   transform: scale(1.2);
@@ -1699,6 +1699,23 @@ body {
   font-size: 14px;
   color: rgba(255, 255, 255, 0.8);
   font-weight: 500;
+}
+
+.customize-item .tab-toggle {
+  min-width: 80px;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.customize-item .tab-toggle.active {
+  background: var(--brick-blue);
+  color: var(--brick-white);
 }
 
 .customize-item input {

--- a/src/components/ui/checkbox.jsx
+++ b/src/components/ui/checkbox.jsx
@@ -2,9 +2,8 @@
 
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { CheckIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 function Checkbox({
   className,
@@ -17,13 +16,8 @@ function Checkbox({
         "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
-      {...props}>
-      <CheckboxPrimitive.Indicator
-        data-slot="checkbox-indicator"
-        className="flex items-center justify-center text-current transition-none">
-        <CheckIcon className="size-3.5" />
-      </CheckboxPrimitive.Indicator>
-    </CheckboxPrimitive.Root>
+      {...props}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- replace checkboxes in the customization modal with button toggles
- remove checkmark indicator from Checkbox component
- update task and modal forms to use checkmark-free Checkbox

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 'setIsDragging' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_688e900cfb4c832cb3818b78cffdfc42