### PR TITLE
feat: add responsible users button with popover

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1462,21 +1462,60 @@ body {
   border-bottom-style: solid;
 }
 
-/* Usuário responsável */
+/* Responsible users button */
 .task-responsible {
-  font-size: 0.85em;
-  color: #666;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   margin-top: 8px;
-  padding: 4px 8px;
-  background-color: #f8f9fa;
-  border-radius: 12px;
-  display: inline-block;
-  border-left: 3px solid #007bff;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
 }
 
-.task-responsible:before {
-  content: '';
-  margin-right: 4px;
+.task-responsible:hover {
+  background-color: #f0f0f0;
+  border-radius: 4px;
+}
+
+.task-responsible .avatar-badge {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85em;
+  background-color: #f8f9fa;
+  border: 1px solid #ddd;
+}
+
+.task-responsible:hover .avatar-badge {
+  border-color: #007bff;
+}
+
+.responsible-user-detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.responsible-user-detail:last-child {
+  margin-bottom: 0;
+}
+
+.responsible-user-detail .detail-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85em;
+  background-color: #f8f9fa;
+  border: 1px solid #ddd;
 }
 
 

--- a/src/LegacyApp.jsx
+++ b/src/LegacyApp.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import './App.css';
 import logoImage from './assets/brickflowbranco.png';
 import { debugLog } from './utils/debugLog';
+import ResponsibleUsersButton from './components/ResponsibleUsersButton';
 
 // Frases absurdas para "Sorte do dia"
 const absurdPhrases = [
@@ -2694,13 +2695,10 @@ function App() {
                               </div>
                               {task.description && <p>{convertUrlsToLinks(task.description)}</p>}
                               {task.responsibleUsers && task.responsibleUsers.length > 0 && (
-                                <div className="task-responsible">
-                                  {task.responsibleUsers.map(user => (
-                                    <div key={user}>
-                                      👤 {getResponsibleUserInfo(user)?.displayName || user}
-                                    </div>
-                                  ))}
-                                </div>
+                                <ResponsibleUsersButton
+                                  users={task.responsibleUsers}
+                                  getUserInfo={getResponsibleUserInfo}
+                                />
                               )}
                               {task.tags?.length > 0 && (
                                 <div className="task-tags">

--- a/src/components/ResponsibleUsersButton.jsx
+++ b/src/components/ResponsibleUsersButton.jsx
@@ -1,0 +1,35 @@
+import { Avatar, AvatarFallback } from "./ui/avatar";
+import { Popover, PopoverTrigger, PopoverContent } from "./ui/popover";
+
+export default function ResponsibleUsersButton({ users = [], getUserInfo }) {
+  if (!users?.length) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button type="button" className="task-responsible">
+          {users.map((username) => {
+            const info = getUserInfo(username);
+            return (
+              <Avatar key={username} className="avatar-badge">
+                <AvatarFallback>{info?.avatar || "👤"}</AvatarFallback>
+              </Avatar>
+            );
+          })}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent>
+        {users.map((username) => {
+          const info = getUserInfo(username);
+          return (
+            <div key={username} className="responsible-user-detail">
+              <span className="detail-avatar">{info?.avatar || "👤"}</span>
+              <span>{info?.displayName || username}</span>
+            </div>
+          );
+        })}
+      </PopoverContent>
+    </Popover>
+  );
+}
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
   build: {
     sourcemap: true, // ⬅️ Isso é o que ativa os sourcemaps
   },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
   test: {
     environment: 'jsdom'
   }


### PR DESCRIPTION
## Summary
- replace text-only responsible block with button showing avatars
- show popover with full responsible user details
- style avatar button and configure alias for `@` imports

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 'setIsDragging' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_688e8ffa975c832ca310a4d8c9df8af7