### PR TITLE
chore: resolve legacy app imports

### DIFF
--- a/src/LegacyApp.jsx
+++ b/src/LegacyApp.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import './App.css';
 import logoImage from './assets/brickflowbranco.png';
 import { debugLog } from './utils/debugLog';
+import ResponsibleUsersButton from './components/ResponsibleUsersButton';
 import { Checkbox } from './components/ui/checkbox';
 
 // Frases absurdas para "Sorte do dia"

--- a/src/components/ResponsibleUsersButton.jsx
+++ b/src/components/ResponsibleUsersButton.jsx
@@ -1,0 +1,3 @@
+export default function ResponsibleUsersButton() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- remove conflict markers and restore missing imports in `LegacyApp.jsx`
- add placeholder `ResponsibleUsersButton` component

## Testing
- `pnpm lint` *(fails: setIsDragging is assigned a value but never used)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f70251bd0832c9f268de5ea7835b4