### PR TITLE
feat: integrate Supabase client for data hooks

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,0 +1,13 @@
+import { createClient } from '@supabase/supabase-js'
+import { debugLog } from '../utils/debugLog'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export function handleSupabaseError(error, context = 'Supabase') {
+  if (error) {
+    debugLog(`⚠️ Erro em ${context}:`, error.message)
+  }
+}


### PR DESCRIPTION
## Summary
- add Supabase client and shared error handler
- refactor users and files hooks to use Supabase client instead of fetch

## Testing
- `npx eslint src/hooks/useUsers.js src/hooks/useFiles.js src/lib/supabaseClient.js`
- `pnpm test`
- `pnpm lint` (fails: 29 problems in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_688f9314e924832c9a1e651db2f37432