### PR TITLE
Filter files by project and subproject

### DIFF
--- a/src/hooks/__tests__/useFiles.test.js
+++ b/src/hooks/__tests__/useFiles.test.js
@@ -1,5 +1,15 @@
-import { renderHook } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/supabaseClient', () => {
+  const supabase = {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: [], error: null })
+  }
+  return { supabase, handleSupabaseError: vi.fn(), __esModule: true }
+})
+
 import { useFiles } from '../useFiles'
 
 function wrapper({ children }) {
@@ -10,5 +20,19 @@ describe('useFiles', () => {
   it('should start with empty list', () => {
     const { result } = renderHook(() => useFiles(null, null, {}), { wrapper })
     expect(result.current.files).toEqual([])
+  })
+
+  it('filters files by project and subproject', () => {
+    const { result } = renderHook(() => useFiles({ id: 1 }, { id: 2 }, {}), { wrapper })
+
+    act(() => {
+      result.current.files.push(
+        { projectId: 1, subProjectId: 2 },
+        { projectId: 3, subProjectId: 2 }
+      )
+    })
+
+    const currentFiles = result.current.getCurrentFiles()
+    expect(currentFiles).toEqual([{ projectId: 1, subProjectId: 2 }])
   })
 })

--- a/src/hooks/useFiles.js
+++ b/src/hooks/useFiles.js
@@ -38,9 +38,10 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
 
   const getCurrentFiles = () => {
     if (!currentSubProject || !files) return []
-    return files.filter(file =>
-      file.subProjectId === currentSubProject.id ||
-      (file.projectId === currentProject?.id && file.subProjectId === currentSubProject.id)
+    return files.filter(
+      file =>
+        file.projectId === currentProject?.id &&
+        file.subProjectId === currentSubProject.id
     )
   }
 


### PR DESCRIPTION
## Summary
- restrict `useFiles` filtering to match both projectId and subProjectId
- add test ensuring files from different projects with the same subProjectId are excluded

## Testing
- `npm test`
- `npm run lint` *(fails: setCurrentBoardType, refreshKey, etc. unused in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688fa629e90c832c924a947fe2d210dc