### PR TITLE
fix: refresh file view after upload

### DIFF
--- a/src/LegacyApp.jsx
+++ b/src/LegacyApp.jsx
@@ -1324,7 +1324,7 @@ function App() {
 
     setIsUploading(false);
     await loadFilesFromSupabase();
-    window.location.reload();
+    setCurrentBoardType('files');
   };
 
   // Função para preview de arquivo


### PR DESCRIPTION
## Summary
- update handleFileUpload to reset view to files instead of reloading page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900290d1f4832c99609f1ad0ea3d42