### PR TITLE
feat: add work reminder overlay to Sudoku

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -259,6 +259,24 @@ body {
   background: rgba(239, 68, 68, 0.4);
 }
 
+.sudoku-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  text-align: center;
+  z-index: 9999;
+  color: var(--brick-white);
+}
+
 /* Main Content */
 .main-content {
   max-width: 1200px;

--- a/src/components/SudokuGame.jsx
+++ b/src/components/SudokuGame.jsx
@@ -4,6 +4,8 @@ const emptyBoard = Array.from({ length: 9 }, () => Array(9).fill(''))
 
 function SudokuGame() {
   const [board, setBoard] = useState(emptyBoard)
+  const [showOverlay, setShowOverlay] = useState(true)
+  const [showGame, setShowGame] = useState(true)
 
   const handleChange = (row, col, value) => {
     const val = value.replace(/[^1-9]/g, '')
@@ -39,22 +41,50 @@ function SudokuGame() {
 
   return (
     <div className="sudoku-box" data-testid="sudoku-game">
-      <h3>🧩 Sudoku</h3>
-      <div className="sudoku-grid">
-        {board.map((row, r) =>
-          row.map((cell, c) => (
-            <input
-              key={`${r}-${c}`}
-              className={`sudoku-cell${isCellValid(board, r, c) ? '' : ' invalid'}`}
-              value={cell}
-              onChange={e => handleChange(r, c, e.target.value)}
-              maxLength={1}
-              inputMode="numeric"
-            />
-          ))
-        )}
-      </div>
-      <button className="btn-primary" onClick={restart}>Reiniciar</button>
+      {showOverlay && (
+        <div className="sudoku-overlay" data-testid="sudoku-warning">
+          <p>O trabalho chama, mas o Sudoku é muito mais divertido. Qual é a sua escolha?</p>
+          <div>
+            <button className="btn-primary" onClick={() => setShowOverlay(false)}>
+              Estou ciente que preciso trabalhar, mas escolho jogar
+            </button>
+            <button
+              className="btn-primary"
+              onClick={() => {
+                setShowGame(false)
+                setShowOverlay(false)
+              }}
+            >
+              Obrigado por me lembrar, prefiro trabalhar a jogar
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showGame ? (
+        <>
+          <h3>🧩 Sudoku</h3>
+          <div className="sudoku-grid">
+            {board.map((row, r) =>
+              row.map((cell, c) => (
+                <input
+                  key={`${r}-${c}`}
+                  className={`sudoku-cell${isCellValid(board, r, c) ? '' : ' invalid'}`}
+                  value={cell}
+                  onChange={e => handleChange(r, c, e.target.value)}
+                  maxLength={1}
+                  inputMode="numeric"
+                />
+              ))
+            )}
+          </div>
+          <button className="btn-primary" onClick={restart}>
+            Reiniciar
+          </button>
+        </>
+      ) : (
+        <div data-testid="work-message">Procrastinação derrotada! De volta ao batente! 💪</div>
+      )}
     </div>
   )
 }

--- a/src/components/__tests__/SudokuGame.test.jsx
+++ b/src/components/__tests__/SudokuGame.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import SudokuGame from '../SudokuGame.jsx'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+expect.extend(matchers)
+
+describe('SudokuGame overlay', () => {
+  afterEach(() => {
+    cleanup()
+  })
+  it('shows overlay initially', () => {
+    render(<SudokuGame />)
+    expect(screen.getByTestId('sudoku-warning')).toBeInTheDocument()
+  })
+
+  it('continues game when choosing to play', () => {
+    render(<SudokuGame />)
+    fireEvent.click(
+      screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
+    )
+    expect(screen.queryByTestId('sudoku-warning')).toBeNull()
+    expect(screen.getByText('Reiniciar')).toBeInTheDocument()
+  })
+
+  it('hides game when choosing to work', () => {
+    render(<SudokuGame />)
+    fireEvent.click(
+      screen.getByText('Obrigado por me lembrar, prefiro trabalhar a jogar')
+    )
+    expect(screen.queryByTestId('sudoku-warning')).toBeNull()
+    expect(screen.getByTestId('work-message')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- warn players with a fullscreen overlay before letting them play Sudoku
- add option to skip the game and see an amusing work reminder
- style overlay to sit above the app and block interaction

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689007720198832cb224990e766df7a5