### PR TITLE
feat: delay sudoku overlay until interaction

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -236,6 +236,7 @@ body {
   padding: 1.5rem;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   text-align: center;
+  position: relative;
 }
 
 .sudoku-grid {
@@ -265,12 +266,13 @@ body {
 }
 
 .sudoku-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0, 0, 0, 0.85);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(135deg, var(--brick-glass), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--brick-border);
+  backdrop-filter: blur(20px);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -278,7 +280,7 @@ body {
   gap: 1rem;
   padding: 1rem;
   text-align: center;
-  z-index: 9999;
+  z-index: 10;
   color: var(--brick-white);
 }
 

--- a/src/components/SudokuGame.jsx
+++ b/src/components/SudokuGame.jsx
@@ -16,10 +16,20 @@ const fixedCells = initialPuzzle.map(row => row.map(cell => cell !== ''))
 
 function SudokuGame() {
   const [board, setBoard] = useState(initialPuzzle.map(row => [...row]))
-  const [showOverlay, setShowOverlay] = useState(true)
+  const [showOverlay, setShowOverlay] = useState(false)
   const [showGame, setShowGame] = useState(true)
+  const [hasInteracted, setHasInteracted] = useState(false)
+
+  const handleFirstInteraction = e => {
+    if (!hasInteracted) {
+      e.preventDefault()
+      setShowOverlay(true)
+      setHasInteracted(true)
+    }
+  }
 
   const handleChange = (row, col, value) => {
+    if (!hasInteracted || showOverlay) return
     const val = value.replace(/[^1-9]/g, '')
     setBoard(prev => {
       if (fixedCells[row][col]) return prev
@@ -77,7 +87,7 @@ function SudokuGame() {
       {showGame ? (
         <>
           <h3>🧩 Sudoku</h3>
-          <div className="sudoku-grid">
+          <div className="sudoku-grid" onMouseDown={handleFirstInteraction}>
             {board.map((row, r) =>
               row.map((cell, c) => (
                 <input

--- a/src/components/__tests__/SudokuGame.test.jsx
+++ b/src/components/__tests__/SudokuGame.test.jsx
@@ -10,13 +10,19 @@ describe('SudokuGame overlay', () => {
   afterEach(() => {
     cleanup()
   })
-  it('shows overlay initially', () => {
+
+  it('appears only after first click', () => {
     render(<SudokuGame />)
+    expect(screen.queryByTestId('sudoku-warning')).toBeNull()
+    const cell = screen.getAllByRole('textbox')[0]
+    fireEvent.mouseDown(cell)
     expect(screen.getByTestId('sudoku-warning')).toBeInTheDocument()
   })
 
   it('continues game when choosing to play', () => {
     render(<SudokuGame />)
+    const cell = screen.getAllByRole('textbox')[0]
+    fireEvent.mouseDown(cell)
     fireEvent.click(
       screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
     )
@@ -26,11 +32,26 @@ describe('SudokuGame overlay', () => {
 
   it('hides game when choosing to work', () => {
     render(<SudokuGame />)
+    const cell = screen.getAllByRole('textbox')[0]
+    fireEvent.mouseDown(cell)
     fireEvent.click(
       screen.getByText('Obrigado por me lembrar, prefiro trabalhar a jogar')
     )
     expect(screen.queryByTestId('sudoku-warning')).toBeNull()
     expect(screen.getByTestId('work-message')).toBeInTheDocument()
+  })
+
+  it('blocks editing until user confirms', () => {
+    render(<SudokuGame />)
+    const cell = screen.getAllByRole('textbox')[2] // pick an empty cell
+    fireEvent.mouseDown(cell)
+    fireEvent.change(cell, { target: { value: '9' } })
+    expect(cell).toHaveValue('')
+    fireEvent.click(
+      screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
+    )
+    fireEvent.change(cell, { target: { value: '9' } })
+    expect(cell).toHaveValue('9')
   })
 })
 
@@ -41,6 +62,7 @@ describe('SudokuGame prefilled cells', () => {
 
   it('renders preset value as read-only', () => {
     render(<SudokuGame />)
+    fireEvent.mouseDown(screen.getAllByRole('textbox')[0])
     fireEvent.click(
       screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
     )


### PR DESCRIPTION
## Summary
- show Sudoku warning overlay only after first click and block cell edits until choice
- center overlay within board using theme color variables
- test that overlay appears on initial click and grid remains locked

## Testing
- `npm test`
- `npm run lint` *(fails: unused vars and other issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68900b38a844832cbacdf57b28bb808f