### PR TITLE
Improve Sudoku overlay structure and styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -266,22 +266,25 @@ body {
 }
 
 .sudoku-overlay {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: linear-gradient(135deg, var(--brick-glass), rgba(255, 255, 255, 0.02));
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.sudoku-overlay-content {
+  max-width: 400px;
+  padding: 1.5rem;
+  background: var(--brick-white);
+  color: #000;
   border: 1px solid var(--brick-border);
-  backdrop-filter: blur(20px);
+  border-radius: 16px;
+  text-align: center;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
   gap: 1rem;
-  padding: 1rem;
-  text-align: center;
-  z-index: 10;
-  color: var(--brick-white);
 }
 
 /* Main Content */

--- a/src/components/SudokuGame.jsx
+++ b/src/components/SudokuGame.jsx
@@ -66,20 +66,25 @@ function SudokuGame() {
     <div className="sudoku-box" data-testid="sudoku-game">
       {showOverlay && (
         <div className="sudoku-overlay" data-testid="sudoku-warning">
-          <p>O trabalho chama, mas o Sudoku é muito mais divertido. Qual é a sua escolha?</p>
-          <div>
-            <button className="btn-primary" onClick={() => setShowOverlay(false)}>
-              Estou ciente que preciso trabalhar, mas escolho jogar
-            </button>
-            <button
-              className="btn-primary"
-              onClick={() => {
-                setShowGame(false)
-                setShowOverlay(false)
-              }}
-            >
-              Obrigado por me lembrar, prefiro trabalhar a jogar
-            </button>
+          <div className="sudoku-overlay-content">
+            <p>
+              O trabalho chama, mas o Sudoku é muito mais divertido. Qual é a sua
+              escolha?
+            </p>
+            <div>
+              <button className="btn-primary" onClick={() => setShowOverlay(false)}>
+                Estou ciente que preciso trabalhar, mas escolho jogar
+              </button>
+              <button
+                className="btn-primary"
+                onClick={() => {
+                  setShowGame(false)
+                  setShowOverlay(false)
+                }}
+              >
+                Obrigado por me lembrar, prefiro trabalhar a jogar
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- separate overlay content from background by adding `sudoku-overlay-content` wrapper
- style overlay as full-screen container with translucent backdrop and styled content box

## Testing
- `pnpm test`
- `pnpm lint` *(fails: pre-existing 13 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68900da6a920832c99baba7a0d6de6a1