### PR TITLE
feat: style sudoku overlay actions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -287,6 +287,13 @@ body {
   gap: 1rem;
 }
 
+.sudoku-overlay-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
 /* Main Content */
 .main-content {
   max-width: 1200px;

--- a/src/components/SudokuGame.jsx
+++ b/src/components/SudokuGame.jsx
@@ -71,12 +71,12 @@ function SudokuGame() {
               O trabalho chama, mas o Sudoku é muito mais divertido. Qual é a sua
               escolha?
             </p>
-            <div>
+            <div className="sudoku-overlay-actions">
               <button className="btn-primary" onClick={() => setShowOverlay(false)}>
                 Estou ciente que preciso trabalhar, mas escolho jogar
               </button>
               <button
-                className="btn-primary"
+                className="btn-secondary"
                 onClick={() => {
                   setShowGame(false)
                   setShowOverlay(false)


### PR DESCRIPTION
## Summary
- group Sudoku overlay buttons and style their layout
- use primary and secondary button styles for overlay options
- add styling for Sudoku overlay actions container

## Testing
- `pnpm lint` (fails: 31 problems)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68900eb32ec0832c8465e2b401437be9