### PR TITLE
style: adjust sudoku overlay actions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -290,7 +290,11 @@ body {
 .sudoku-overlay-actions {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+  width: 100%;
+}
+
+.sudoku-overlay-actions .btn-primary {
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- stack Sudoku overlay buttons vertically with wider spacing
- ensure primary action fills available width

## Testing
- `pnpm lint` *(fails: 'setCurrentBoardType' is assigned a value but never used ...)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689011a29e08832c88558f35f944fcca