### PR TITLE
feat: block final sudoku move and show overlay

### DIFF
--- a/src/components/SudokuGame.jsx
+++ b/src/components/SudokuGame.jsx
@@ -19,6 +19,7 @@ function SudokuGame() {
   const [showOverlay, setShowOverlay] = useState(false)
   const [showGame, setShowGame] = useState(true)
   const [hasInteracted, setHasInteracted] = useState(false)
+  const [showFinalOverlay, setShowFinalOverlay] = useState(false)
 
   const handleFirstInteraction = e => {
     if (!hasInteracted) {
@@ -29,10 +30,17 @@ function SudokuGame() {
   }
 
   const handleChange = (row, col, value) => {
-    if (!hasInteracted || showOverlay) return
+    if (!hasInteracted || showOverlay || showFinalOverlay) return
     const val = value.replace(/[^1-9]/g, '')
+    if (fixedCells[row][col]) return
+
+    const emptyCells = board.flat().filter(cell => cell === '').length
+    if (emptyCells === 1 && val !== '') {
+      setShowFinalOverlay(true)
+      return
+    }
+
     setBoard(prev => {
-      if (fixedCells[row][col]) return prev
       const newBoard = prev.map(r => [...r])
       newBoard[row][col] = val
       return newBoard
@@ -85,6 +93,17 @@ function SudokuGame() {
                 Obrigado por me lembrar, prefiro trabalhar a jogar
               </button>
             </div>
+          </div>
+        </div>
+      )}
+
+      {showFinalOverlay && (
+        <div className="sudoku-overlay" data-testid="sudoku-final">
+          <div className="sudoku-overlay-content">
+            <p>
+              Fracassar tão perto do sucesso é uma arte. Parabéns, você é um artista
+              incompreendido! Mas vamos lembrar que aqui não é lugar para joguinhos.
+            </p>
           </div>
         </div>
       )}

--- a/src/components/__tests__/SudokuGame.test.jsx
+++ b/src/components/__tests__/SudokuGame.test.jsx
@@ -71,3 +71,31 @@ describe('SudokuGame prefilled cells', () => {
     expect(cell).toHaveAttribute('readOnly')
   })
 })
+
+describe('SudokuGame final overlay', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('blocks final move and shows message', () => {
+    render(<SudokuGame />)
+    const cells = screen.getAllByRole('textbox')
+    const editable = cells.filter(c => !c.hasAttribute('readOnly'))
+    fireEvent.mouseDown(editable[0])
+    fireEvent.click(
+      screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
+    )
+
+    for (let i = 0; i < 50; i++) {
+      fireEvent.change(editable[i], { target: { value: '1' } })
+    }
+    const lastCell = editable[50]
+    fireEvent.change(lastCell, { target: { value: '9' } })
+    expect(lastCell).toHaveValue('')
+    expect(
+      screen.getByText(
+        'Fracassar tão perto do sucesso é uma arte. Parabéns, você é um artista incompreendido! Mas vamos lembrar que aqui não é lugar para joguinhos.'
+      )
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- block board update when trying to fill last empty sudoku cell and display playful overlay
- test last-cell block and overlay message

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Fast refresh only works..., React Hook useEffect has a missing dependency, 31 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6890168dbd48832ca918b6975d2ccc30