### PR TITLE
test: ensure final overlay triggers with single empty cell

### DIFF
--- a/src/components/__tests__/SudokuGame.test.jsx
+++ b/src/components/__tests__/SudokuGame.test.jsx
@@ -86,10 +86,11 @@ describe('SudokuGame final overlay', () => {
       screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
     )
 
-    for (let i = 0; i < 50; i++) {
-      fireEvent.change(editable[i], { target: { value: '1' } })
-    }
-    const lastCell = editable[50]
+    // fill all editable cells except the last one
+    editable.slice(0, -1).forEach(cell => {
+      fireEvent.change(cell, { target: { value: '1' } })
+    })
+    const lastCell = editable[editable.length - 1]
     fireEvent.change(lastCell, { target: { value: '9' } })
     expect(lastCell).toHaveValue('')
     expect(


### PR DESCRIPTION
## Summary
- adjust Sudoku final overlay test to programmatically fill board leaving one empty cell
- assert last move keeps cell blank and shows final message

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890194cd414832c942e937984c334ed