### PR TITLE
Add PropTypes to project components

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
     "next-themes": "^0.4.6",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      prop-types:
+        specifier: ^15.8.1
+        version: 15.8.1
       react:
         specifier: ^19.1.0
         version: 19.1.0

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 export default function ProjectCard({ project, onSelect }) {
   return (
     <div className="project-card" onClick={() => onSelect(project)}>
@@ -5,4 +7,13 @@ export default function ProjectCard({ project, onSelect }) {
       {project.description && <p>{project.description}</p>}
     </div>
   )
+}
+
+ProjectCard.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string,
+  }).isRequired,
+  onSelect: PropTypes.func.isRequired,
 }

--- a/src/components/ProjectsView.jsx
+++ b/src/components/ProjectsView.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import ProjectCard from './ProjectCard'
 
 export default function ProjectsView({ projects, onSelect }) {
@@ -12,4 +13,19 @@ export default function ProjectsView({ projects, onSelect }) {
       ))}
     </div>
   )
+}
+
+ProjectsView.propTypes = {
+  projects: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+    })
+  ),
+  onSelect: PropTypes.func.isRequired,
+}
+
+ProjectsView.defaultProps = {
+  projects: [],
 }

--- a/src/components/ResponsibleUsersButton.jsx
+++ b/src/components/ResponsibleUsersButton.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 
-export default function ResponsibleUsersButton({ users = [], getUserInfo }) {
-  if (!users || users.length === 0) return null
+export default function ResponsibleUsersButton({ users, getUserInfo }) {
   const [open, setOpen] = useState(false)
+  if (!users || users.length === 0) return null
 
   const toggle = (e) => {
     e.stopPropagation()
@@ -25,4 +26,14 @@ export default function ResponsibleUsersButton({ users = [], getUserInfo }) {
       )}
     </div>
   )
+}
+
+ResponsibleUsersButton.propTypes = {
+  users: PropTypes.arrayOf(PropTypes.string),
+  getUserInfo: PropTypes.func,
+}
+
+ResponsibleUsersButton.defaultProps = {
+  users: [],
+  getUserInfo: undefined,
 }


### PR DESCRIPTION
## Summary
- add PropTypes definitions to project-related components
- document default props for project and user lists
- include prop-types dependency

## Testing
- `npx eslint src/components/ProjectCard.jsx src/components/ProjectsView.jsx src/components/ResponsibleUsersButton.jsx`
- `pnpm lint` *(fails: 12 errors, 18 warnings)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689128a21d10832ca893d8cebc6ec4c1