### PR TITLE
test: use setter for files state

### DIFF
--- a/src/hooks/__tests__/useFiles.test.js
+++ b/src/hooks/__tests__/useFiles.test.js
@@ -26,14 +26,23 @@ describe('useFiles', () => {
     const { result } = renderHook(() => useFiles({ id: 1 }, { id: 2 }, {}), { wrapper })
 
     act(() => {
-      result.current.files.push(
+      result.current.setFiles([
         { projectId: 1, subProjectId: 2 },
         { projectId: 3, subProjectId: 2 }
-      )
+      ])
     })
 
-    const currentFiles = result.current.getCurrentFiles()
-    expect(currentFiles).toEqual([{ projectId: 1, subProjectId: 2 }])
+    expect(result.current.getCurrentFiles()).toEqual([
+      { projectId: 1, subProjectId: 2 }
+    ])
+
+    act(() => {
+      result.current.setFiles([
+        { projectId: 3, subProjectId: 2 }
+      ])
+    })
+
+    expect(result.current.getCurrentFiles()).toEqual([])
   })
 
   it('allows updating dragging state', () => {

--- a/src/hooks/useFiles.js
+++ b/src/hooks/useFiles.js
@@ -108,6 +108,7 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
 
   return {
     files,
+    setFiles,
     isDragging,
     setIsDragging,
     previewFile,


### PR DESCRIPTION
## Summary
- expose `setFiles` from `useFiles` hook
- use setter in `useFiles` tests and verify filtering after state changes

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68912c1d0a20832cad474f9032461396