### PR TITLE
feat: validate Supabase env vars

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -4,6 +4,18 @@ import { debugLog } from '../utils/debugLog'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missing = [
+    !supabaseUrl && 'VITE_SUPABASE_URL',
+    !supabaseAnonKey && 'VITE_SUPABASE_ANON_KEY'
+  ]
+    .filter(Boolean)
+    .join(' and ')
+  const message = `Missing environment variable(s): ${missing}`
+  console.warn(message)
+  throw new Error(message)
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 export function handleSupabaseError(error, context = 'Supabase') {


### PR DESCRIPTION
## Summary
- ensure Supabase URL and anon key env vars are present before creating client

## Testing
- `pnpm lint` *(fails: 31 problems, 13 errors, 18 warnings)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68912a51c400832c9624d34e76b62080