### PR TITLE
Refresh file list after upload

### DIFF
--- a/src/hooks/useFiles.js
+++ b/src/hooks/useFiles.js
@@ -83,6 +83,7 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
         debugLog('❌ Erro no upload:', error.message)
       }
     }
+    await loadFilesFromSupabase()
     event.target.value = ''
   }
 


### PR DESCRIPTION
## Summary
- refresh files state after uploading by calling `loadFilesFromSupabase`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: set of existing lint errors across unrelated files)*
- `npx eslint src/hooks/useFiles.js`


------
https://chatgpt.com/codex/tasks/task_e_68912eb84d04832c94c1944e8a31e20a