### PR TITLE
fix: guard mobile hook for SSR

### DIFF
--- a/src/hooks/use-mobile.js
+++ b/src/hooks/use-mobile.js
@@ -6,13 +6,19 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(undefined)
 
   React.useEffect(() => {
+    // Ensure SSR safety by exiting early when `window` is unavailable.
+    if (typeof window === "undefined") return
+
+    const getIsMobile = () =>
+      typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(getIsMobile())
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange);
+    setIsMobile(getIsMobile())
+    return () => mql.removeEventListener("change", onChange)
   }, [])
 
   return !!isMobile


### PR DESCRIPTION
## Summary
- ensure `useIsMobile` safely checks for `window` before use
- document SSR-safe early return

## Testing
- `pnpm exec eslint src/hooks/use-mobile.js`
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891335a3f04832cbc4f78e3af0da7c3