### PR TITLE
Refresh file list after upload

### DIFF
--- a/src/hooks/useFiles.js
+++ b/src/hooks/useFiles.js
@@ -79,11 +79,11 @@ export function useFiles(currentProject, currentSubProject, currentUser) {
         }
 
         await saveFileToSupabase(fileData)
+        await loadFilesFromSupabase()
       } catch (error) {
         debugLog('❌ Erro no upload:', error.message)
       }
     }
-    await loadFilesFromSupabase()
     event.target.value = ''
   }
 


### PR DESCRIPTION
## Summary
- reload the files list immediately after each upload for up-to-date UI

## Testing
- `pnpm lint` *(fails: 'no-unused-vars' errors, existing)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68915c4ba5a4832cb614a5ff428b75e5