### PR TITLE
Reset Sudoku final overlay on restart

### DIFF
--- a/src/components/SudokuGame.jsx
+++ b/src/components/SudokuGame.jsx
@@ -45,10 +45,13 @@ function SudokuGame() {
       newBoard[row][col] = val
       return newBoard
     })
-  }
+  } 
 
   const restart = () => {
     setBoard(initialPuzzle.map(row => [...row]))
+    setShowOverlay(false)
+    setHasInteracted(false)
+    setShowFinalOverlay(false)
   }
 
   const isCellValid = (board, row, col) => {

--- a/src/components/__tests__/SudokuGame.test.jsx
+++ b/src/components/__tests__/SudokuGame.test.jsx
@@ -99,4 +99,22 @@ describe('SudokuGame final overlay', () => {
       )
     ).toBeInTheDocument()
   })
+
+  it('hides final overlay after restart', () => {
+    render(<SudokuGame />)
+    const cells = screen.getAllByRole('textbox')
+    const editable = cells.filter(c => !c.hasAttribute('readOnly'))
+    fireEvent.mouseDown(editable[0])
+    fireEvent.click(
+      screen.getByText('Estou ciente que preciso trabalhar, mas escolho jogar')
+    )
+    editable.slice(0, -1).forEach(cell => {
+      fireEvent.change(cell, { target: { value: '1' } })
+    })
+    const lastCell = editable[editable.length - 1]
+    fireEvent.change(lastCell, { target: { value: '9' } })
+    expect(screen.getByTestId('sudoku-final')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Reiniciar'))
+    expect(screen.queryByTestId('sudoku-final')).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary
- ensure restarting the Sudoku game clears overlays and interaction state
- add unit test confirming restart hides the final overlay

## Testing
- `pnpm test`
- `pnpm lint` *(fails: 'setCurrentBoardType' is assigned a value but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68916767c7ec832c871fffeeba53601f